### PR TITLE
誕生日の近い友人の月ごとの並び順をわかりやすくする

### DIFF
--- a/app/controllers/friends_controller.rb
+++ b/app/controllers/friends_controller.rb
@@ -5,15 +5,14 @@ class FriendsController < ApplicationController
     @thismonth = Date.today.month
     @nextmonth = Date.today.prev_month(-1).month
     @nextnextmonth = Date.today.prev_month(-2).month
-
     if user_signed_in?
       user_id = current_user.id
     else
       user_id = -1
     end
-    @friends_thismonth = Friend.select { |friend| user_id == friend.user_id && friend.birth.present? && friend.birth.month == @thismonth }
-    @friends_nextmonth = Friend.select { |friend| user_id == friend.user_id && friend.birth.present? && friend.birth.month == @nextmonth }
-    @friends_nextnextmonth = Friend.select { |friend| user_id == friend.user_id && friend.birth.present? && friend.birth.month == @nextnextmonth }
+    @friends_thismonth = Friend.reorder(:day).select{ |friend| user_id == friend.user_id && friend.birth.present? && friend.birth.month == @thismonth }
+    @friends_nextmonth = Friend.reorder(:day).select { |friend| user_id == friend.user_id && friend.birth.present? && friend.birth.month == @nextmonth }
+    @friends_nextnextmonth = Friend.reorder(:day).select { |friend| user_id == friend.user_id && friend.birth.present? && friend.birth.month == @nextnextmonth }
   end
 
   def new
@@ -23,6 +22,7 @@ class FriendsController < ApplicationController
   def create
     @friend = Friend.new(friend_params)
     if @friend.save
+      @friend.update( day: @friend.birth.to_s.match(/..$/)[0] )
       redirect_to friends_path
     else
       render 'new'
@@ -40,6 +40,7 @@ class FriendsController < ApplicationController
   def update
     friend =Friend.find(params[:id])
     if friend.update(friend_params)
+      friend.update( day: friend.birth.to_s.match(/..$/)[0] )
       redirect_to friend_path
     else
       render :edit

--- a/app/controllers/missions_controller.rb
+++ b/app/controllers/missions_controller.rb
@@ -9,9 +9,11 @@ class MissionsController < ApplicationController
     else
       user_id = -1
     end
+
     @friends_thismonth = Friend.select { |friend| user_id == friend.user_id && friend.birth.present? && friend.birth.month == @thismonth }
     @friends_nextmonth = Friend.select { |friend| user_id == friend.user_id && friend.birth.present? && friend.birth.month == @nextmonth }
     @friends_nextnextmonth = Friend.select { |friend| user_id == friend.user_id && friend.birth.present? && friend.birth.month == @nextnextmonth }
+
   end
 
   def show

--- a/app/controllers/missions_controller.rb
+++ b/app/controllers/missions_controller.rb
@@ -9,11 +9,9 @@ class MissionsController < ApplicationController
     else
       user_id = -1
     end
-
-    @friends_thismonth = Friend.select { |friend| user_id == friend.user_id && friend.birth.present? && friend.birth.month == @thismonth }
-    @friends_nextmonth = Friend.select { |friend| user_id == friend.user_id && friend.birth.present? && friend.birth.month == @nextmonth }
-    @friends_nextnextmonth = Friend.select { |friend| user_id == friend.user_id && friend.birth.present? && friend.birth.month == @nextnextmonth }
-
+    @friends_thismonth = Friend.reorder(:day).select{ |friend| user_id == friend.user_id && friend.birth.present? && friend.birth.month == @thismonth }
+    @friends_nextmonth = Friend.reorder(:day).select { |friend| user_id == friend.user_id && friend.birth.present? && friend.birth.month == @nextmonth }
+    @friends_nextnextmonth = Friend.reorder(:day).select { |friend| user_id == friend.user_id && friend.birth.present? && friend.birth.month == @nextnextmonth }
   end
 
   def show

--- a/app/controllers/missions_controller.rb
+++ b/app/controllers/missions_controller.rb
@@ -12,7 +12,6 @@ class MissionsController < ApplicationController
     @friends_thismonth = Friend.select { |friend| user_id == friend.user_id && friend.birth.present? && friend.birth.month == @thismonth }
     @friends_nextmonth = Friend.select { |friend| user_id == friend.user_id && friend.birth.present? && friend.birth.month == @nextmonth }
     @friends_nextnextmonth = Friend.select { |friend| user_id == friend.user_id && friend.birth.present? && friend.birth.month == @nextnextmonth }
-    
   end
 
   def show

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -3,7 +3,4 @@ class Friend < ApplicationRecord
   has_many :missions, dependent: :destroy
   validates :name, presence: true, length: { maximum: 7 }
   default_scope -> { order(name: :asc) }
-
-
-
 end

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -3,4 +3,7 @@ class Friend < ApplicationRecord
   has_many :missions, dependent: :destroy
   validates :name, presence: true, length: { maximum: 7 }
   default_scope -> { order(name: :asc) }
+
+
+
 end

--- a/app/views/shared/_friends.html.haml
+++ b/app/views/shared/_friends.html.haml
@@ -9,4 +9,3 @@
             = ""
           -else
             = "誕生日 #{friend.birth.to_s(:date3)}"
-            -# = I18n.l(friend.birth)

--- a/db/migrate/20200406074733_add_day_to_friends.rb
+++ b/db/migrate/20200406074733_add_day_to_friends.rb
@@ -1,0 +1,5 @@
+class AddDayToFriends < ActiveRecord::Migration[5.2]
+  def change
+    add_column :friends, :day, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_14_045137) do
+ActiveRecord::Schema.define(version: 2020_04_06_074733) do
 
   create_table "friends", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2020_03_14_045137) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
+    t.integer "day"
     t.index ["user_id"], name: "index_friends_on_user_id"
   end
 


### PR DESCRIPTION
# What
もうすぐ誕生日のフレンドたちが、きちんと誕生日を迎える順の並び方に変更し、便利にした。

# Why
ユーザー目線のインターフェイスにするため。
default_scopeの副作用の重度を理解する為。
default_scopeのリカバーの仕方を学ぶ為。

# Detail
friendテーブルではdefault_scopeを使っている。本来は保守性を保つ為に使用してはいけない。ただ、使わなければcurrent_user.friendsで呼び出している部分に対する並び替えの方法がまだわかっていない為、今後devise内のスコープ処理を勉強してから改善する。
上記default_scopeが早速悪さをして、"もうすぐ誕生日"のフレンドの並び順が誕生日順になっていなかった。それに対し、新しいカラム「day」を作成し、月ごとの誕生日の日付部分だけをコントローラで抽出し、その日付を整数とみなしてascで並び替えを行った。orderが効かない為、.reorderを使用して並び替えた。