### PR TITLE
日付管理の微調整(今日日付のミッションがスクロールで若干隠れてしまっていたバグ)

### DIFF
--- a/app/views/shared/_missions.html.haml
+++ b/app/views/shared/_missions.html.haml
@@ -2,7 +2,7 @@
   = link_to mission_path(mission, :anchor => 'anchor') do
     .contents__content
       .picture
-        -if mission.datetime > Date.today
+        -if mission.datetime >= Date.today
           %p= I18n.l(mission.datetime)
         -else
           %p.past= mission.datetime.to_s(:date3)


### PR DESCRIPTION
# What
過去日付に"past"クラス名で定義していたが、今日日付にもpastが定義されてしまっていた。
> を、>= に修正。

# Why
ユーザーが直感的に予定を把握出来るようにするため。